### PR TITLE
fix: off-by-one error at edge of volume

### DIFF
--- a/nsdcode/interp_wrapper.py
+++ b/nsdcode/interp_wrapper.py
@@ -56,7 +56,7 @@ def interp_wrapper(vol, coords, interptype='cubic'):
 
     # bad locations must get set to NaN
     bad = np.any(isnotfinite(coords), axis=0)
-    coords[:, bad] = 0
+    coords[:, bad] = -1
 
     # out of range must become NaN, too
     bad = np.any(


### PR DESCRIPTION
Closes https://github.com/cvnlab/nsdcode/issues/21.

Fixes an off-by-one error caused by conversion from MATLAB to Python indexing.